### PR TITLE
Add suffix for text and watch. Folder confict

### DIFF
--- a/src/Mail/Sender.js
+++ b/src/Mail/Sender.js
@@ -46,12 +46,12 @@ class MailSender {
        * Loop over views to find the best match
        */
       const viewsCopy = views.slice().filter((view) => {
-        if (view.endsWith('.text')) {
+        if (view.endsWith('.text') || view.endsWith('-text')) {
           returnHash['text'] = view
           return false
         }
 
-        if (view.endsWith('.watch')) {
+        if (view.endsWith('.watch') || view.endsWith('-watch')) {
           returnHash['watch'] = view
           return false
         }


### PR DESCRIPTION
Edge translates full stops as a directory separator,
So using `.` as the identifier means that a folder has to be created 
for each mail.
Left the old way for backward compatibility