### PR TITLE
Allow set SMTP_PORT on config

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -25,7 +25,7 @@ module.exports = {
   smtp: {
     driver: 'smtp',
     pool: true,
-    port: 2525,
+    port: Env.get('SMTP_PORT', 2525),
     host: Env.get('SMTP_HOST'),
     secure: false,
     auth: {


### PR DESCRIPTION
## Proposed changes

It assumes the port is 2525, but if I have a local server for development and a production SMTP server with different ports, it's needed to be configurable

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-mail/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

N/A
