### PR TITLE
Patch for working with Mailgun regions

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -79,7 +79,7 @@ module.exports = {
   mailgun: {
     driver: 'mailgun',
     domain: Env.get('MAILGUN_DOMAIN'),
-    region: Env.get('MAILGUN_REGION'),
+    region: Env.get('MAILGUN_REGION', ''),
     apiKey: Env.get('MAILGUN_API_KEY'),
     extras: {}
   },

--- a/examples/config.js
+++ b/examples/config.js
@@ -79,6 +79,7 @@ module.exports = {
   mailgun: {
     driver: 'mailgun',
     domain: Env.get('MAILGUN_DOMAIN'),
+    region: Env.get('MAILGUN_REGION'),
     apiKey: Env.get('MAILGUN_API_KEY'),
     extras: {}
   },

--- a/src/Mail/Drivers/Mailgun.js
+++ b/src/Mail/Drivers/Mailgun.js
@@ -49,7 +49,7 @@ class MailGunTransporter {
    * @return {String}
    */
   get endpoint () {
-    return `https://api.mailgun.net/v3/${this.config.domain}/messages.mime`
+    return `https://api.${this.config.region.length > 0 ? this.config.region.toLowerCase() + '.' : ''}mailgun.net/v3/${this.config.domain}/messages.mime`
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

Mailgun added opportunity of region selection in control panel. Currently available 2 regions: US and EU. Domains added in EU region is not visible in main API (US) because base URL for EU region is like _https://api.eu.mailgun.net/v3/<domain>_. Mailgun driver in Mail provider works wrong if domain situated in EU region. 

## Types of changes
 - Region defining in _.env_ 
 - Defining default region in _<app_root>/config/mail.js_
 - Building url with region in _src/Mail/Drivers/Mailgun.js_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-mail/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No
